### PR TITLE
Added expand by function to BoundingBox#d

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Matthieu Pizenberg <matthieu.pizenberg@gmail.com> (intersections)
 Folkert de Vries <folkert@folkertdev.nl> (length parameterization, delaunay triangulation)
 Felix Scheinost <felix.scheinost@gmail.com> (Sphere3d)
 Jakub Hampl <honitom@seznam.cz> (convex hull)
+Lalit Umbarkar <lalit.umbarkar9@gmail.com>

--- a/src/BoundingBox2d.elm
+++ b/src/BoundingBox2d.elm
@@ -12,7 +12,7 @@ module BoundingBox2d exposing
     , fromExtrema, singleton, from, hull, intersection, aggregate, containingPoints
     , extrema, minX, maxX, minY, maxY, dimensions, midX, midY, centerPoint, centroid
     , contains, isContainedIn, intersects, overlappingBy, separatedBy
-    , scaleAbout, translateBy, translateIn
+    , scaleAbout, translateBy, translateIn, expandBy
     )
 
 {-| A `BoundingBox2d` is a rectangular box in 2D defined by its minimum and
@@ -52,7 +52,7 @@ box of an object than the object itself, such as:
 
 # Transformations
 
-@docs scaleAbout, translateBy, translateIn
+@docs scaleAbout, translateBy, translateIn, expandBy
 
 -}
 
@@ -922,3 +922,34 @@ is equivalent to
 translateIn : Direction2d -> Float -> BoundingBox2d -> BoundingBox2d
 translateIn direction distance boundingBox =
     translateBy (Vector2d.withLength distance direction) boundingBox
+
+
+{-| Expand the bounding box in all the directions by given distance;
+
+
+    expandBy_ : Float
+    expandBy_ =
+        3
+
+
+    --> BoundingBox2d.expandBy expandBy_ exampleBox
+    -->     { minX = 0
+    -->     , maxX = 11
+    -->     , minY = -1
+    -->     , maxY = 9
+    -->     }
+
+-}
+expandBy : Float -> BoundingBox2d -> Maybe BoundingBox2d
+expandBy by boundingBox_ =
+    let
+        centroidPt_ =
+            centroid boundingBox_
+    in
+    Just <|
+        fromExtrema
+            { minX = minX boundingBox_ - by
+            , minY = minY boundingBox_ - by
+            , maxX = maxX boundingBox_ + by
+            , maxY = maxY boundingBox_ + by
+            }

--- a/src/BoundingBox2d.elm
+++ b/src/BoundingBox2d.elm
@@ -926,7 +926,6 @@ translateIn direction distance boundingBox =
 
 {-| Expand the bounding box in all the directions by given distance;
 
-
     expandBy_ : Float
     expandBy_ =
         3
@@ -939,17 +938,36 @@ translateIn direction distance boundingBox =
     -->     , maxY = 9
     -->     }
 
+    Function returns Nothing In case of expandBy is more than or equal to half of diagonal length,
+    where it is assumed that it was shrunk up to the size of a point,
+    and the centroid of the BoundingBox can be used instead.
+
 -}
 expandBy : Float -> BoundingBox2d -> Maybe BoundingBox2d
 expandBy by boundingBox_ =
     let
-        centroidPt_ =
+        centroidPt =
             centroid boundingBox_
+
+        halfDiagonalLen =
+            Vector2d.length <|
+                Vector2d.from
+                    (Point2d.fromCoordinates ( minX boundingBox_, minY boundingBox_ ))
+                    centroidPt
+
+        resultingBox =
+            fromExtrema
+                { minX = minX boundingBox_ - by
+                , minY = minY boundingBox_ - by
+                , maxX = maxX boundingBox_ + by
+                , maxY = maxY boundingBox_ + by
+                }
     in
-    Just <|
-        fromExtrema
-            { minX = minX boundingBox_ - by
-            , minY = minY boundingBox_ - by
-            , maxX = maxX boundingBox_ + by
-            , maxY = maxY boundingBox_ + by
-            }
+    if by > 0 then
+        Just <| resultingBox
+
+    else if by < 0 && (-1 * by) < halfDiagonalLen then
+        Just <| resultingBox
+
+    else
+        Nothing

--- a/src/BoundingBox3d.elm
+++ b/src/BoundingBox3d.elm
@@ -1045,3 +1045,36 @@ is equivalent to
 translateIn : Direction3d -> Float -> BoundingBox3d -> BoundingBox3d
 translateIn direction distance boundingBox =
     translateBy (Vector3d.withLength distance direction) boundingBox
+
+
+{-| Expand the bounding box in all the directions by given distance;
+
+
+    expandBy_ : Float
+    expandBy_ =
+        3
+
+
+    --> BoundingBox3d.expandBy expandBy_ exampleBox
+    -->     { minX = 0
+    -->     , maxX = 11
+    -->     , minY = -1
+    -->     , maxY = 9
+    -->     }
+
+-}
+expandBy : Float -> BoundingBox3d -> Maybe BoundingBox3d
+expandBy by boundingBox_ =
+    let
+        centroidPt_ =
+            centroid boundingBox_
+    in
+    Just <|
+        fromExtrema
+            { minX = minX boundingBox_ - by
+            , minY = minY boundingBox_ - by
+            , minZ = minZ boundingBox_ - by
+            , maxX = maxX boundingBox_ + by
+            , maxY = maxY boundingBox_ + by
+            , maxZ = maxZ boundingBox_ + by
+            }


### PR DESCRIPTION
Added function expand by to BoundingBox2d and BoundingBox3d
Code is reformatted using correct version of `elm-format`.
Related Issue: #60  


Pull request checklist:
  - Is the pull request from a dedicated branch in your fork instead of `master`?   **Yes**
  - Have you added yourself to the AUTHORS file? **Yes** 
  - Is "Allow edits from maintainers" enabled? **Yes**
  - Is the code formatted using the same version of `elm-format` as the rest of
    `elm-geometry`? **Yes**
  - Is code wrapped to 80 columns? **Yes**
  - **Have you added tests for new functionality?** **No**
  - Have you added documentation for new functionality? **Yes**
